### PR TITLE
Support to Android 12

### DIFF
--- a/creditCardNfcReader/src/main/java/com/pro100svitlo/creditCardNfcReader/utils/CardNfcUtils.java
+++ b/creditCardNfcReader/src/main/java/com/pro100svitlo/creditCardNfcReader/utils/CardNfcUtils.java
@@ -26,8 +26,12 @@ public class CardNfcUtils {
     public CardNfcUtils(final Activity pActivity) {
         mActivity = pActivity;
         mNfcAdapter = NfcAdapter.getDefaultAdapter(mActivity);
-        mPendingIntent = PendingIntent.getActivity(mActivity, 0,
-                new Intent(mActivity, mActivity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
+        if(android.os.Build.VERSION.SDK_INT >=23){
+            mPendingIntent = PendingIntent.getActivity(mActivity, 0,new Intent(mActivity, mActivity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+        }else{
+            mPendingIntent = PendingIntent.getActivity(mActivity, 0,new Intent(mActivity, mActivity.getClass()).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0);
+        }
+        
     }
 
     public void disableDispatch() {


### PR DESCRIPTION
This should fix the problem:

java.lang.RuntimeException: Unable to start activity ComponentInfo{com.myapp/com.jackbayliss.nfcreader.NfcCardReaderActivity}: java.lang.IllegalArgumentException: com.myapp: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.